### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pysa.py
+++ b/pysa.py
@@ -190,7 +190,7 @@ def main():
     if options.salt:
         s.show_salt(output, module)
 
-    # save to madeira accound
+    # save to madeira account
     if options.l:
         m = Madeira(user, uid, output, module)
         m.send()

--- a/pysa/puppet/converter.py
+++ b/pysa/puppet/converter.py
@@ -72,7 +72,7 @@ SECTION_EQ = {
     }
 SECTION_CALL_EQ = dict([(key,SECTION_EQ[key].capitalize()) for key in SECTION_EQ])
 
-# define subsclasses equivalency
+# define subclasses equivalency
 SUBCLASS_EQ = {
     'packages'  : {
         MAIN_SECTION : 'provider',
@@ -146,7 +146,7 @@ class PuppetConverter():
     def run(self):
         Tools.l(INFO, "running", 'run', self)
 
-        #empty imput
+        #empty input
         if not self.__input:
             Tools.l(ERR, "empty input", 'run', self)
             return {}

--- a/pysa/salt/converter.py
+++ b/pysa/salt/converter.py
@@ -209,7 +209,7 @@ class SaltConverter():
     def run(self):
         Tools.l(INFO, "running", 'run', self)
 
-        #empty imput
+        #empty input
         if not self.__input:
             Tools.l(ERR, "empty input", 'run', self)
             return {}
@@ -290,7 +290,7 @@ class SaltConverter():
         Tools.l(INFO, "processing data complete", 'process_data', self)
         return data
 
-    # ganaration method
+    # generation method
     @GeneralException
     def __generate_classes(self, data):
         for manifest in sorted(data):

--- a/pysa/scanner/actions/package.py
+++ b/pysa/scanner/actions/package.py
@@ -315,7 +315,7 @@ class ScannerPackage(ScannerBase):
 
     def query_deps(self, package):
         """
-        query package's denpendency in the list and update the user/core package list
+        query package's dependency in the list and update the user/core package list
         """
 
         if self.scan_mode == 'sub_rpm':

--- a/pysa/scanner/actions/source.py
+++ b/pysa/scanner/actions/source.py
@@ -59,7 +59,7 @@ class ScannerSource(ScannerBase):
                 else:
                     continue
 
-                if scm=='svn':  #if svn scm, need to check subdirctory
+                if scm=='svn':  #if svn scm, need to check subdirectory
                     head, tail = os.path.split(dirpath)
                     while head and tail:
                         if head in self.user_repos['svn']:


### PR DESCRIPTION
There are small typos in:
- pysa.py
- pysa/puppet/converter.py
- pysa/salt/converter.py
- pysa/scanner/actions/package.py
- pysa/scanner/actions/source.py

Fixes:
- Should read `input` rather than `imput`.
- Should read `subdirectory` rather than `subdirctory`.
- Should read `subclasses` rather than `subsclasses`.
- Should read `generation` rather than `ganaration`.
- Should read `dependency` rather than `denpendency`.
- Should read `account` rather than `accound`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md